### PR TITLE
Add word-wrap of link in post

### DIFF
--- a/src/components/PostContent.module.css
+++ b/src/components/PostContent.module.css
@@ -88,6 +88,10 @@
   margin-top: 1rem;
 }
 
+.post a {
+  word-wrap: break-word;
+}
+
 .post code:not([class*="language-"]) {
   padding: 0.2em 0.4em;
   margin: 0;


### PR DESCRIPTION
post内のaタグをbreak-wordするようにしました

## before

<img width="300" alt="Image from iOS" src="https://user-images.githubusercontent.com/30946750/142139440-ef1feac2-5a15-4650-ac8a-b44190193a1c.png">

## after

<img width="300" alt="スクリーンショット 2021-11-17 13 55 59" src="https://user-images.githubusercontent.com/30946750/142139769-e03637ec-acc5-4dba-a35b-50e67061efe1.png">


