### PR TITLE
Editorを複数人登録できるようにしました

### DIFF
--- a/data/posts/storybook-interactive-stories.md
+++ b/data/posts/storybook-interactive-stories.md
@@ -1,7 +1,9 @@
 ---
 title: "Interactive storiesを使ってStorybook上でユーザー操作の状態を確認する"
 author: "nus3"
-editor: "nakajmg"
+editor:
+  - "nakajmg"
+  - "sakito"
 createdAt: "2021-11-29"
 summary: "Storybookに新しく追加されたInteractive storiesについて紹介します"
 tags:

--- a/src/pages/posts/[slug].tsx
+++ b/src/pages/posts/[slug].tsx
@@ -4,7 +4,7 @@ import { getAllPosts, getPostBySlug } from "../../utils/posts";
 import type { PostData } from "../../utils/posts";
 import styles from "./post.module.css";
 import "prismjs/themes/prism.css";
-import { getMemberByName, Member } from "../../utils/members";
+import { getMemberByName, getMembersByName, Member } from "../../utils/members";
 import Link from "next/link";
 import { MemberIcon } from "../../components/MemberIcon";
 import { Tags } from "../../components/Tags";
@@ -58,8 +58,8 @@ type Props = {
 
 const Post = ({ post }: Props) => {
   const author = getMemberByName(post.metaData.author);
-  const editor = post.metaData.editor
-    ? getMemberByName(post.metaData.editor)
+  const editors = post.metaData.editor
+    ? getMembersByName(post.metaData.editor)
     : "";
   return (
     <Layout
@@ -76,7 +76,13 @@ const Post = ({ post }: Props) => {
       </div>
       <div className={styles.authors}>
         <Author author={author} />
-        {editor && <Author author={editor} label="Editor" />}
+        {editors && (
+          <div className={styles.editors}>
+            {editors.map((editor) => (
+              <Author key={editor.name} author={editor} label="Editor" />
+            ))}
+          </div>
+        )}
       </div>
       <PostContent>
         <div dangerouslySetInnerHTML={{ __html: post.content }} />

--- a/src/pages/posts/post.module.css
+++ b/src/pages/posts/post.module.css
@@ -25,15 +25,21 @@
 }
 .authors {
   display: flex;
+  margin: 1.5rem 0;
 }
-.author + .author {
+.editors {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+.author + .editors {
   margin-left: 16px;
   padding-left: 16px;
   border-left: 1px solid #d3d3d3;
 }
 .author {
   display: flex;
-  margin: 1.5rem 0;
+  height: 60px;
   color: #333;
 }
 .author a {

--- a/src/utils/members.ts
+++ b/src/utils/members.ts
@@ -68,6 +68,17 @@ export function getMemberByName(name: string): Member {
   return foundMember;
 }
 
+export function getMembersByName(name: string | string[]): Member[] {
+  if (!Array.isArray(name)) {
+    return [getMemberByName(name)];
+  }
+
+  const fountMembers = name.map((n) => {
+    return getMemberByName(n);
+  });
+  return fountMembers;
+}
+
 function isGuest(name: string): boolean {
   return members.every((member) => member.name !== name);
 }

--- a/src/utils/members.ts
+++ b/src/utils/members.ts
@@ -73,10 +73,10 @@ export function getMembersByName(name: string | string[]): Member[] {
     return [getMemberByName(name)];
   }
 
-  const fountMembers = name.map((n) => {
+  const foundMembers = name.map((n) => {
     return getMemberByName(n);
   });
-  return fountMembers;
+  return foundMembers;
 }
 
 function isGuest(name: string): boolean {

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -6,7 +6,7 @@ import { markdownToHtml } from "./markdown/markdownToHtml";
 type PostMetaData = {
   title: string;
   author: string;
-  editor?: string;
+  editor?: string | string[];
   createdAt: string;
   updatedAt: string;
   tags: string[];


### PR DESCRIPTION
close #29 

いろんな人が書いた記事をレビューしてくれるので、Editor複数人登録できたらいいなという思いから
markdownのeditorプロパティにstringの配列を指定できるようにしました

<img width="1008" alt="スクリーンショット 2022-01-06 14 51 11" src="https://user-images.githubusercontent.com/30946750/148336989-5a01874d-fa01-4762-a1d8-3c16760d91b2.png">

一応全員登録できる(けどこんなにeditorいないはずなので2行になることは基本ないはず・・)
<img width="1015" alt="スクリーンショット 2022-01-06 15 04 46" src="https://user-images.githubusercontent.com/30946750/148336996-41466333-2fb1-469e-96b2-840261dcad95.png">

スマホで見た場合
<img width="386" alt="スクリーンショット 2022-01-06 15 05 22" src="https://user-images.githubusercontent.com/30946750/148336997-5f5c493c-f557-4928-bff0-6bd33e7f5fc4.png">
