### PR TITLE
Chrome96リリースノートの`Support calc(<number>) where only accepts <integer>`のexampleの修正

### DIFF
--- a/data/posts/release-chrome-96.md
+++ b/data/posts/release-chrome-96.md
@@ -246,13 +246,12 @@ https://developer.mozilla.org/ja/docs/Web/CSS/@media/prefers-contrast
 cssの`calc()`関数でintegerしか受け取らないような場所でもnumberを指定できるようになりました。
 もっとも近い整数に丸められます。
 
-例えば、下記はいずれも`width: 0px`と同義です。
+例えば、下記はいずれも`column-count: 1`と同義です。
 
 ```css
 .example {
-    width: calc(5px - 10px);
-    width: calc(-5px);
-    width: 0px;
+  column-count: calc(1.2);
+  column-count: calc(0.6);
 }
 ```
 


### PR DESCRIPTION
close #42 

サンプルコードではwidth(`<length-percentage>`型)を使っていたので、`<integer>`型であるcolumn-countを使うように修正
