### PR TITLE
update members style

### DIFF
--- a/src/components/AuthorAndEditor.tsx
+++ b/src/components/AuthorAndEditor.tsx
@@ -9,7 +9,12 @@ import { MemberIcon } from "./MemberIcon";
 const Author = ({ author, label }: { author: Member; label?: string }) => {
   return (
     <div css={authorStyle}>
-      <MemberIcon width="60" height="60" name={author.name} />
+      <Link href={`/members/${author.name}`} passHref>
+        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+        <a className="memberIcon">
+          <MemberIcon width="60" height="60" name={author.name} />
+        </a>
+      </Link>
       <div className="authorInfo">
         <div className="label">{label ? label : "Author"}</div>
         <span className="authorName">
@@ -51,6 +56,12 @@ const authorStyle = css`
   .label {
     width: 100%;
     font-size: 0.6rem;
+    font-weight: bold;
+  }
+  .memberIcon {
+    img {
+      border-radius: 4px;
+    }
   }
 
   a {
@@ -70,6 +81,7 @@ const authorStyle = css`
   .authorName {
     font-size: 0.9rem;
     line-height: 1;
+    margin-top: 4px;
   }
 
   .authorInfo {
@@ -84,10 +96,12 @@ const authorStyle = css`
   .authorInfo ul {
     list-style: none;
     display: flex;
+    align-items: center;
+    margin-top: 4px;
   }
 
   .authorInfo ul li:not(:last-of-type) {
-    margin-right: 0.6rem;
+    margin-right: 8px;
   }
 `;
 

--- a/src/pages/members/[name].tsx
+++ b/src/pages/members/[name].tsx
@@ -6,20 +6,30 @@ import { getPostsByAuthor, PostData } from "../../utils/posts";
 import { Posts } from "../../components/Posts";
 import { MemberIcon } from "../../components/MemberIcon";
 import { css } from "@emotion/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faGithubAlt, faTwitter } from "@fortawesome/free-brands-svg-icons";
 
 const MemberSection = ({ member }: { member: Member }) => {
   return (
     <div css={style}>
-      <MemberIcon name={member.name} width="200" height="200" />
-      <h1 className="memberName">{`${member.name}${
+      <div className="memberIcon">
+        <MemberIcon name={member.name} width="160" height="160" />
+      </div>
+      <h2 className="memberName">{`${member.name}${
         member.active ? "" : "(inactive)"
-      }`}</h1>
+      }`}</h2>
       <ul className="links">
         <li>
-          <a href={`https://twitter.com/${member.twitterId}`}>Twitter</a>
+          <FontAwesomeIcon icon={faTwitter} width="24" height="24" />
+          <a href={`https://twitter.com/${member.twitterId}`}>
+            @{member.twitterId}
+          </a>
         </li>
         <li>
-          <a href={`https://github.com/${member.githubUsername}`}>GitHub</a>
+          <FontAwesomeIcon icon={faGithubAlt} width="24" height="24" />
+          <a href={`https://github.com/${member.githubUsername}`}>
+            @{member.githubUsername}
+          </a>
         </li>
       </ul>
     </div>
@@ -35,9 +45,11 @@ const MemberPage = ({
 }) => {
   return (
     <Layout title={member.name}>
-      <MemberSection member={member} />
-      <div className="posts">
-        <Posts posts={posts} />
+      <div css={layoutStyle}>
+        <MemberSection member={member} />
+        <div css={postsStyle}>
+          <Posts posts={posts} />
+        </div>
       </div>
     </Layout>
   );
@@ -76,25 +88,52 @@ export const getStaticPaths: GetStaticPaths = async () => {
 export default MemberPage;
 
 const style = css`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  .memberIcon {
+    img {
+      border-radius: 4px;
+    }
+  }
 
   .memberName {
-    font-size: 3rem;
+    font-size: 1.8rem;
+    font-weight: normal;
   }
 
   .links {
     list-style: none;
-    display: flex;
+    margin-top: 16px;
   }
 
   .links li {
-    font-size: 1.4rem;
     margin-right: 1.2rem;
+    display: flex;
+    gap: 8px;
+    align-items: center;
   }
+  @media (max-width: 600px) {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+`;
 
-  .posts {
-    margin-top: 1.2rem;
+const postsStyle = css`
+  border-left: 1px solid #ebebeb;
+  padding-left: 16px;
+  @media (max-width: 600px) {
+    border: none;
+    padding-left: 0;
+    margin-top: 16px;
+    border-top: 1px solid #ebebeb;
+  }
+`;
+
+const layoutStyle = css`
+  padding: 8px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 16px;
+  @media (max-width: 600px) {
+    display: block;
   }
 `;

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -5,6 +5,8 @@ import { activeMembers, Member } from "../../utils/members";
 import Link from "next/link";
 import { MemberIcon } from "../../components/MemberIcon";
 import { css } from "@emotion/react";
+import { faGithubAlt, faTwitter } from "@fortawesome/free-brands-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const MemberItem = ({ member }: { member: Member }) => {
   return (
@@ -17,7 +19,7 @@ const MemberItem = ({ member }: { member: Member }) => {
         <div className="links">
           <ul>
             <li>
-              Twitter:{" "}
+              <FontAwesomeIcon icon={faTwitter} width="18" height="18" />{" "}
               <a
                 href={`https://twitter.com/${member.twitterId}`}
                 target="_blank"
@@ -25,7 +27,7 @@ const MemberItem = ({ member }: { member: Member }) => {
               >{`@${member.twitterId}`}</a>
             </li>
             <li>
-              GitHub:{" "}
+              <FontAwesomeIcon icon={faGithubAlt} width="18" height="18" />{" "}
               <a
                 target="_blank"
                 rel="noreferrer noopener"
@@ -86,6 +88,9 @@ const memberStyle = css`
   }
 
   .details .links ul li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     font-size: 0.8rem;
   }
 `;

--- a/src/pages/members/index.tsx
+++ b/src/pages/members/index.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { Layout } from "../../components/Layout";
 import { PageLayout } from "../../components/PageLayout";
-import { activeMembers, Member } from "../../utils/members";
+import { members, Member } from "../../utils/members";
 import Link from "next/link";
 import { MemberIcon } from "../../components/MemberIcon";
 import { css } from "@emotion/react";
@@ -15,6 +15,7 @@ const MemberItem = ({ member }: { member: Member }) => {
       <div className="details">
         <p className="name">
           <Link href={`/members/${member.name}`}>{member.name}</Link>
+          {!member.active ? <span className="inactive">(inactive)</span> : ""}
         </p>
         <div className="links">
           <ul>
@@ -46,7 +47,7 @@ const Members = () => (
     <PageLayout>
       <h2>Members</h2>
       <ul css={membersStyle}>
-        {activeMembers.map((member) => {
+        {members.map((member) => {
           return <MemberItem key={member.name} member={member} />;
         })}
       </ul>
@@ -92,6 +93,11 @@ const memberStyle = css`
     align-items: center;
     gap: 8px;
     font-size: 0.8rem;
+  }
+  .inactive {
+    color: gray;
+    font-size: 0.8rem;
+    padding-left: 8px;
   }
 `;
 

--- a/src/utils/members.ts
+++ b/src/utils/members.ts
@@ -7,12 +7,6 @@ export type Member = {
 
 export const members: Member[] = [
   {
-    name: "sakito",
-    twitterId: "__sakito__",
-    githubUsername: "sakito21",
-    active: true,
-  },
-  {
     name: "shisama",
     twitterId: "shisama_",
     githubUsername: "shisama",
@@ -53,6 +47,12 @@ export const members: Member[] = [
     twitterId: "nus3_",
     githubUsername: "nus3",
     active: true,
+  },
+  {
+    name: "sakito",
+    twitterId: "__sakito__",
+    githubUsername: "sakito21",
+    active: false,
   },
 ];
 


### PR DESCRIPTION
memberページのレイアウト変更

![image](https://user-images.githubusercontent.com/1995370/166178274-56e60ff4-2319-4c1d-b7f4-cdf79720c9ea.png)

![image](https://user-images.githubusercontent.com/1995370/166178280-b7de0fc1-aa8d-46a0-8ca8-cec995e32cdc.png)

inactive表示足した

<img width="1101" alt="image" src="https://user-images.githubusercontent.com/1995370/166179108-1ed2c158-837e-47e7-9b8d-23bc180d830d.png">

記事ページのAuthorのアイコンクリックでmemberページに飛べるようにした